### PR TITLE
修复微信扫描支付的小问题

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "standard",
+    "parserOptions": {
+        "sourceType": "module"
+    },
+    "rules": {
+        "indent": [
+            "error",
+            "tab"
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "warn",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/lib/weixin.js
+++ b/lib/weixin.js
@@ -75,9 +75,9 @@ Weixin.prototype.verifyResponse = function(response,format){
 
 Weixin.prototype.query = function(data){
   
-  if(data.transaction_id){
+  if(data.trade_no){
     data.transaction_id = data.trade_no;
-    delete data.transaction_id;
+    delete data.trade_no;
   }
   var config = this.config;
   var params = {
@@ -148,10 +148,10 @@ Weixin.prototype.create = function(datas){
       break;
     case "weixin_native" : 
       params.trade_type = "NATIVE";
-      if(!datas.openid){
-        return Promise.reject("缺少openid");
+      if(!datas.product_id){
+        return Promise.reject("缺少product_id");
       }
-      params.openid = datas.openid
+      params.product_id = datas.product_id
       break;
     case "weixin_web" :
       

--- a/package.json
+++ b/package.json
@@ -30,14 +30,22 @@
     "debug": "~2.2.0",
     "md5": "^2.0.0",
     "moment": "^2.10.6",
-    "underscore": "^1.8.3",
-    "utf8": "^2.1.1",
-    "uuid": "^2.0.1",
-     "xml": "^1.0.0",
-    "xml2js": "^0.4.15",
-    "urlencode":"1.1.0",
     "random-gen": "0.1.0",
     "request": "^2.64.0",
-    "request-promise": "4.2.1"
+    "request-promise": "4.2.1",
+    "underscore": "^1.8.3",
+    "urlencode": "1.1.0",
+    "utf8": "^2.1.1",
+    "uuid": "^2.0.1",
+    "xml": "^1.0.0",
+    "xml2js": "^0.4.15"
+  },
+  "devDependencies": {
+    "eslint": "^4.18.2",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-standard": "^3.0.1"
   }
 }


### PR DESCRIPTION
[bugfix]  weixin 'orderquery' need 'transaction_id' not 'trade_no'
[bugfix]  weixin 'orderquery' need 'transaction_id' not 'trade_no'