### PR TITLE
微信验证签名需要跳过‘空’参数

### DIFF
--- a/lib/weixin.js
+++ b/lib/weixin.js
@@ -21,6 +21,10 @@ function sign(params, key) {
   return md5(temp).toUpperCase();
 }
 
+function isValidSignParam(value, key) {
+  return (value && (key !== 'sign'));
+}
+
 class Weixin {
   constructor(params){
     if(params){
@@ -40,7 +44,7 @@ Weixin.prototype.verify = function(params){
   if (!sig) {
     return {result:false,msg:"verify sig failed"};
   }
-  var temp = common.queryize(_.omit(params, ['sign']), false) + '&key=' + config.key;
+  var temp = common.queryize(_.pick(params, isValidSignParam), false) + '&key=' + config.key;
 
   if( (md5(temp).toUpperCase() === sig ) != true ){
     return {result:false,msg:"verify weixin params"}


### PR DESCRIPTION
[bug fix] Weixin.verify not skip 'empty' params
样例数据
```xml
<xml><return_code><![CDATA[SUCCESS]]></return_code>
<return_msg><![CDATA[OK]]></return_msg>
<appid><![CDATA[wx426b3015555a46be]]></appid>
<mch_id><![CDATA[1900009851]]></mch_id>
<nonce_str><![CDATA[8VMExX7gt3imLgbM]]></nonce_str>
<sign><![CDATA[D115FD37C70247F7DECF192CE6F56B86]]></sign>
<result_code><![CDATA[SUCCESS]]></result_code>
<openid><![CDATA[oHZx6uKDzfAzljIKn_gP7mu99O3M]]></openid>
<is_subscribe><![CDATA[N]]></is_subscribe>
<trade_type><![CDATA[NATIVE]]></trade_type>
<bank_type><![CDATA[CFT]]></bank_type>
<total_fee>1</total_fee>
<fee_type><![CDATA[CNY]]></fee_type>
<transaction_id><![CDATA[4200000065201803063807324676]]></transaction_id>
<out_trade_no><![CDATA[SyVcLyh_z]]></out_trade_no>
<attach><![CDATA[]]></attach>
<time_end><![CDATA[20180306180002]]></time_end>
<trade_state><![CDATA[SUCCESS]]></trade_state>
<cash_fee>1</cash_fee>
</xml>
```
其中attach是个"空"值，修改前
```URL
appid=wx426b3015555a46be&attach=&bank_type=CFT&cash_fee=1&fee_type=CNY&is_subscribe=N&mch_id=1900009851&nonce_str=8VMExX7gt3imLgbM&openid=oHZx6uKDzfAzljIKn_gP7mu99O3M&out_trade_no=SyVcLyh_z&result_code=SUCCESS&return_code=SUCCESS&return_msg=OK&time_end=20180306180002&total_fee=1&trade_state=SUCCESS&trade_type=NATIVE&transaction_id=4200000065201803063807324676&key=8934e7d15453e97507ef794cf7b0519d
```
md5是**FCB55E3F2FAE7EAB5D92ECC8013D254C**与预期**D115FD37C70247F7DECF192CE6F56B86**不一致
```URL
appid=wx426b3015555a46be&bank_type=CFT&cash_fee=1&fee_type=CNY&is_subscribe=N&mch_id=1900009851&nonce_str=8VMExX7gt3imLgbM&openid=oHZx6uKDzfAzljIKn_gP7mu99O3M&out_trade_no=SyVcLyh_z&result_code=SUCCESS&return_code=SUCCESS&return_msg=OK&time_end=20180306180002&total_fee=1&trade_state=SUCCESS&trade_type=NATIVE&transaction_id=4200000065201803063807324676&key=8934e7d15453e97507ef794cf7b0519d
```

修改后跳过了‘空’值，md5验证通过

